### PR TITLE
Added Programmable Formatting

### DIFF
--- a/example/lib/generated_nodes.dart
+++ b/example/lib/generated_nodes.dart
@@ -50,7 +50,7 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
     });
     // Generate random edges
     final edges = <InfiniteCanvasEdge>[];
-    for (var i = 0; i < nodes.length; i++) {
+    for (int i = 0; i < nodes.length; i++) {
       final from = nodes[i];
       final to = nodes[Random().nextInt(nodes.length)];
       if (from != to) {

--- a/example/lib/level_of_detail.dart
+++ b/example/lib/level_of_detail.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:infinite_canvas/infinite_canvas.dart';
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -355,10 +355,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "323b7c70073cccf6b9b8d8b334be418a3293cfb612a560dc2737160a37bf61bd"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.6"
+    version: "0.6.5"
   just_audio:
     dependency: transitive
     description:
@@ -411,10 +411,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -451,10 +451,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:
@@ -712,10 +712,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
@@ -949,5 +949,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=2.19.0-345.0.dev <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.3.0"

--- a/lib/src/presentation/state/controller.dart
+++ b/lib/src/presentation/state/controller.dart
@@ -44,6 +44,24 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   Offset? marqueeStart, marqueeEnd;
   LocalKey? linkStart;
 
+  void _format() {
+    for (InfiniteCanvasNode node in nodes) {
+      _formatter!(node);
+    }
+  }
+
+  bool _formatterHasChanged = false;
+  Function(InfiniteCanvasNode)? _formatter;
+  set formatter(Function(InfiniteCanvasNode) value) {
+    _formatterHasChanged = _formatter == value;
+
+    if (_formatterHasChanged == false) return;
+
+    _formatter = value;
+    _format();
+    notifyListeners();
+  }
+
   Offset? _linkEnd;
   Offset? get linkEnd => _linkEnd;
   set linkEnd(Offset? value) {
@@ -366,9 +384,5 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
     final scale = matrix.getMaxScaleOnAxis();
     final size = constraints.biggest;
     return offset & size / scale;
-  }
-
-  void format() {
-    // TODO: Layout graph like a force-directed, tree, flowchart or grid
   }
 }

--- a/lib/src/presentation/state/controller.dart
+++ b/lib/src/presentation/state/controller.dart
@@ -213,6 +213,9 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
       if (index == -1) continue;
       final current = nodes[index];
       current.update(offset: current.offset + delta);
+      if (_formatter != null) {
+        _formatter!(current);
+      }
     }
     mousePosition = position;
     notifyListeners();
@@ -257,6 +260,9 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   }
 
   void add(InfiniteCanvasNode child) {
+    if (_formatter != null) {
+      _formatter!(child);
+    }
     nodes.add(child);
     notifyListeners();
   }

--- a/lib/src/presentation/state/controller.dart
+++ b/lib/src/presentation/state/controller.dart
@@ -41,6 +41,7 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   late final transform = TransformationController();
   Matrix4 get matrix => transform.value;
   Offset mousePosition = Offset.zero;
+  Offset? mouseDragStart;
   Offset? marqueeStart, marqueeEnd;
   LocalKey? linkStart;
 
@@ -207,7 +208,9 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   }
 
   void moveSelection(Offset position) {
-    final delta = toLocal(position) - toLocal(mousePosition);
+    final delta = mouseDragStart != null
+        ? toLocal(position) - toLocal(mouseDragStart!)
+        : toLocal(position);
     for (final key in _selected) {
       final index = nodes.indexWhere((e) => e.key == key);
       if (index == -1) continue;
@@ -217,7 +220,6 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
         _formatter!(current);
       }
     }
-    mousePosition = position;
     notifyListeners();
   }
 

--- a/lib/src/presentation/state/controller.dart
+++ b/lib/src/presentation/state/controller.dart
@@ -53,7 +53,7 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   bool _formatterHasChanged = false;
   Function(InfiniteCanvasNode)? _formatter;
   set formatter(Function(InfiniteCanvasNode) value) {
-    _formatterHasChanged = _formatter == value;
+    _formatterHasChanged = _formatter != value;
 
     if (_formatterHasChanged == false) return;
 

--- a/lib/src/presentation/view/canvas.dart
+++ b/lib/src/presentation/view/canvas.dart
@@ -258,6 +258,7 @@ class InfiniteCanvasState extends State<InfiniteCanvas> {
               scaleEnabled: controller.canvasMoveEnabled,
               onInteractionStart: (details) {
                 controller.mousePosition = details.focalPoint;
+                controller.mouseDragStart = controller.mousePosition;
               },
               onInteractionUpdate: (details) {
                 if (!controller.mouseDown) {
@@ -270,6 +271,7 @@ class InfiniteCanvasState extends State<InfiniteCanvas> {
                 }
                 controller.mousePosition = details.focalPoint;
               },
+              onInteractionEnd: (_) => controller.mouseDragStart = null,
               minScale: controller.minScale,
               maxScale: controller.maxScale,
               boundaryMargin: const EdgeInsets.all(double.infinity),

--- a/lib/src/presentation/view/canvas.dart
+++ b/lib/src/presentation/view/canvas.dart
@@ -19,16 +19,16 @@ import '../widgets/node_renderer.dart';
 /// This can not be shrink wrapped, so it should be used
 /// as a full screen / expanded widget.
 class InfiniteCanvas extends StatefulWidget {
-  const InfiniteCanvas({
-    super.key,
-    required this.controller,
-    this.gridSize = const Size.square(50),
-    this.menuVisible = true,
-    this.menus = const [],
-    this.backgroundBuilder,
-    this.drawVisibleOnly = false,
-    this.canAddEdges = false,
-  });
+  const InfiniteCanvas(
+      {super.key,
+      required this.controller,
+      this.gridSize = const Size.square(50),
+      this.menuVisible = true,
+      this.menus = const [],
+      this.backgroundBuilder,
+      this.drawVisibleOnly = false,
+      this.canAddEdges = false,
+      this.edgesUseStraightLines = false});
 
   final InfiniteCanvasController controller;
   final Size gridSize;
@@ -36,6 +36,7 @@ class InfiniteCanvas extends StatefulWidget {
   final List<MenuEntry> menus;
   final bool drawVisibleOnly;
   final bool canAddEdges;
+  final bool edgesUseStraightLines;
   final Widget Function(BuildContext, Rect)? backgroundBuilder;
 
   @override
@@ -295,6 +296,7 @@ class InfiniteCanvasState extends State<InfiniteCanvas> {
                               ?.rect
                               .center,
                           linkEnd: controller.linkEnd,
+                          straightLines: widget.edgesUseStraightLines,
                         ),
                       ),
                       Positioned.fill(

--- a/lib/src/presentation/widgets/edge_renderer.dart
+++ b/lib/src/presentation/widgets/edge_renderer.dart
@@ -6,17 +6,18 @@ import 'inline_painter.dart';
 
 /// A widget that renders all the edges in the [InfiniteCanvas].
 class InfiniteCanvasEdgeRenderer extends StatelessWidget {
-  const InfiniteCanvasEdgeRenderer({
-    super.key,
-    required this.controller,
-    required this.edges,
-    this.linkStart,
-    this.linkEnd,
-  });
+  const InfiniteCanvasEdgeRenderer(
+      {super.key,
+      required this.controller,
+      required this.edges,
+      this.linkStart,
+      this.linkEnd,
+      this.straightLines = false});
 
   final InfiniteCanvasController controller;
   final List<InfiniteCanvasEdge> edges;
   final Offset? linkStart, linkEnd;
+  final bool straightLines;
 
   @override
   Widget build(BuildContext context) {
@@ -73,17 +74,22 @@ class InfiniteCanvasEdgeRenderer extends StatelessWidget {
     String? label,
   }) {
     final colors = Theme.of(context).colorScheme;
-    // Draw bezier curve from fromRect.center to toRect.center
+    // Draw line from fromRect.center to toRect.center
     final path = Path();
     path.moveTo(fromOffset.dx, fromOffset.dy);
-    path.cubicTo(
-      fromOffset.dx,
-      fromOffset.dy,
-      fromOffset.dx,
-      toOffset.dy,
-      toOffset.dx,
-      toOffset.dy,
-    );
+
+    if (straightLines) {
+      path.moveTo(toOffset.dx, toOffset.dy);
+    } else {
+      path.cubicTo(
+        fromOffset.dx,
+        fromOffset.dy,
+        fromOffset.dx,
+        toOffset.dy,
+        toOffset.dx,
+        toOffset.dy,
+      );
+    }
     canvas.drawPath(path, brush);
     if (label != null) {
       final textPainter = TextPainter(
@@ -102,12 +108,12 @@ class InfiniteCanvasEdgeRenderer extends StatelessWidget {
         ),
         textDirection: TextDirection.ltr,
       )..layout();
-      // Render label on bezier curve
+      // Render label on line
       Offset textOffset = Offset(
         (fromOffset.dx + toOffset.dx) / 2,
         (fromOffset.dy + toOffset.dy) / 2,
       );
-      // Center on curve
+      // Center on curve, if used
       final pathMetrics = path.computeMetrics();
       final pathMetric = pathMetrics.first;
       final pathLength = pathMetric.length;


### PR DESCRIPTION
We like your package and want to improve on it. In our fork, we've added better drag event handling and added optional formatting via a callback function. Here's a simple formatter that snaps the content to the grid:

```dart
    controller.formatter = (InfiniteCanvasNode node) {
      // snap to grid
      node.offset = Offset(
          (node.offset.dx / gridSize.width).roundToDouble() * gridSize.width,
          (node.offset.dy / gridSize.height).roundToDouble() * gridSize.height);
    };
 ```