### PR TITLE
Improved node movement and resizing

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+# platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,12 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		31BCEFCADEEAFE122E7D148B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B3E385715010023A0EEAB98 /* Pods_RunnerTests.framework */; };
+		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		8E31A2BB989EE1BAC429BF06 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBADDD88394F1AD3396C3193 /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,12 +42,20 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		067E5ABFE66F7B7FCA599FA9 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		07C3316D47ABE243F3919E68 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1830679441504107E26D9138 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		25F53903B9E0B88B64A07543 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		2B3E385715010023A0EEAB98 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
+		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		960F130CF9C2A3FBDA8F953A /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -53,21 +63,61 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
-		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CBADDD88394F1AD3396C3193 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC4FCF180B926363E75D1320 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		84D4BCBF215AFE2C2C4DDE5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				31BCEFCADEEAFE122E7D148B /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8E31A2BB989EE1BAC429BF06 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2C1254C55CA66D5FF2C4375C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CBADDD88394F1AD3396C3193 /* Pods_Runner.framework */,
+				2B3E385715010023A0EEAB98 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		331C8082294A63A400263BE5 /* RunnerTests */ = {
+			isa = PBXGroup;
+			children = (
+				331C807B294A618700263BE5 /* RunnerTests.swift */,
+			);
+			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		54CA020DB4DCBB6440492577 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				25F53903B9E0B88B64A07543 /* Pods-Runner.debug.xcconfig */,
+				1830679441504107E26D9138 /* Pods-Runner.release.xcconfig */,
+				07C3316D47ABE243F3919E68 /* Pods-Runner.profile.xcconfig */,
+				EC4FCF180B926363E75D1320 /* Pods-RunnerTests.debug.xcconfig */,
+				067E5ABFE66F7B7FCA599FA9 /* Pods-RunnerTests.release.xcconfig */,
+				960F130CF9C2A3FBDA8F953A /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -79,14 +129,6 @@
 			name = Flutter;
 			sourceTree = "<group>";
 		};
-		331C8082294A63A400263BE5 /* RunnerTests */ = {
-			isa = PBXGroup;
-			children = (
-				331C807B294A618700263BE5 /* RunnerTests.swift */,
-			);
-			path = RunnerTests;
-			sourceTree = "<group>";
-		};
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
@@ -94,6 +136,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				54CA020DB4DCBB6440492577 /* Pods */,
+				2C1254C55CA66D5FF2C4375C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -128,9 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				7D3ECF8E697577025CCC893A /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
-				331C807E294A63A400263BE5 /* Frameworks */,
 				331C807F294A63A400263BE5 /* Resources */,
+				84D4BCBF215AFE2C2C4DDE5D /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -146,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				C2163574984388291D042329 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				9B024075D6A83BDFE5A26C6D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -168,7 +215,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {
@@ -229,6 +276,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -236,6 +284,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		7D3ECF8E697577025CCC893A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -251,6 +321,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		9B024075D6A83BDFE5A26C6D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C2163574984388291D042329 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -343,7 +452,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -376,7 +485,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AE0B7B92F70575B8D7E0D07E /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = EC4FCF180B926363E75D1320 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -394,7 +503,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 89B67EB44CE7B6631473024E /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 067E5ABFE66F7B7FCA599FA9 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,7 +519,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 640959BDD8F10B91D80A66BE /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 960F130CF9C2A3FBDA8F953A /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -471,7 +580,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -520,7 +629,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/example/lib/generated_nodes.dart
+++ b/example/lib/generated_nodes.dart
@@ -62,18 +62,11 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
         ));
       }
     }
-    controller = InfiniteCanvasController(nodes: nodes, edges: edges);
-    // controller.formatter = (node) {
-    //   // snap to grid
-    //   node.offset = Offset(
-    //     (node.offset.dx / gridSize.width).roundToDouble() * gridSize.width,
-    //     (node.offset.dy / gridSize.height).roundToDouble() * gridSize.height,
-    //   );
-    //   node.size = Size(
-    //     (node.size.width / gridSize.width).roundToDouble() * gridSize.width,
-    //     (node.size.height / gridSize.height).roundToDouble() * gridSize.height,
-    //   );
-    // };
+    controller = InfiniteCanvasController(
+        nodes: nodes,
+        edges: edges,
+        snapMovementToGrid: true,
+        snapResizeToGrid: true);
   }
 
   @override
@@ -202,7 +195,8 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
                   final result = fd.cycle;
                   messenger.showSnackBar(
                     SnackBar(
-                      content: Text('Cycle found: ${result.map((e) => e.key.toString()).join(', ')}'),
+                      content: Text(
+                          'Cycle found: ${result.map((e) => e.key.toString()).join(', ')}'),
                     ),
                   );
                 },

--- a/example/lib/generated_nodes.dart
+++ b/example/lib/generated_nodes.dart
@@ -26,7 +26,7 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
       return InfiniteCanvasNode(
         key: UniqueKey(),
         label: 'Node $index',
-        allowResize: true,
+        resizeMode: ResizeMode.cornersAndEdges,
         offset: Offset(
           Random().nextDouble() * 5000,
           Random().nextDouble() * 5000,
@@ -95,7 +95,7 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
                   final node = InfiniteCanvasNode(
                     key: UniqueKey(),
                     label: 'Node ${controller.nodes.length}',
-                    allowResize: true,
+                    resizeMode: ResizeMode.cornersAndEdges,
                     offset: controller.mousePosition,
                     size: Size(
                       Random().nextDouble() * 200 + 100,
@@ -127,7 +127,7 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
                   final node = InfiniteCanvasNode(
                     key: UniqueKey(),
                     label: 'Node ${controller.nodes.length}',
-                    allowResize: true,
+                    resizeMode: ResizeMode.cornersAndEdges,
                     offset: controller.mousePosition,
                     size: Size(
                       Random().nextDouble() * 200 + 100,
@@ -162,7 +162,7 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
                   final node = InfiniteCanvasNode(
                     key: UniqueKey(),
                     label: 'Node ${controller.nodes.length}',
-                    allowResize: true,
+                    resizeMode: ResizeMode.cornersAndEdges,
                     offset: controller.mousePosition,
                     size: Size(
                       Random().nextDouble() * 200 + 100,
@@ -198,8 +198,7 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
                   final result = fd.cycle;
                   messenger.showSnackBar(
                     SnackBar(
-                      content: Text(
-                          'Cycle found: ${result.map((e) => e.key.toString()).join(', ')}'),
+                      content: Text('Cycle found: ${result.map((e) => e.key.toString()).join(', ')}'),
                     ),
                   );
                 },

--- a/example/lib/generated_nodes.dart
+++ b/example/lib/generated_nodes.dart
@@ -63,13 +63,17 @@ class _GeneratedNodesState extends State<GeneratedNodes> {
       }
     }
     controller = InfiniteCanvasController(nodes: nodes, edges: edges);
-    controller.formatter = (node) {
-      // snap to grid
-      node.offset = Offset(
-        (node.offset.dx / gridSize.width).roundToDouble() * gridSize.width,
-        (node.offset.dy / gridSize.height).roundToDouble() * gridSize.height,
-      );
-    };
+    // controller.formatter = (node) {
+    //   // snap to grid
+    //   node.offset = Offset(
+    //     (node.offset.dx / gridSize.width).roundToDouble() * gridSize.width,
+    //     (node.offset.dy / gridSize.height).roundToDouble() * gridSize.height,
+    //   );
+    //   node.size = Size(
+    //     (node.size.width / gridSize.width).roundToDouble() * gridSize.width,
+    //     (node.size.height / gridSize.height).roundToDouble() * gridSize.height,
+    //   );
+    // };
   }
 
   @override

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   audio_session:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   charcode:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.8"
+    version: "0.0.9"
   js:
     dependency: transitive
     description:
@@ -391,6 +391,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.2"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -411,26 +435,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.11.0"
   nested:
     dependency: transitive
     description:
@@ -451,10 +475,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_drawing:
     dependency: transitive
     description:
@@ -648,10 +672,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   sqflite:
     dependency: transitive
     description:
@@ -672,18 +696,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -712,10 +736,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -844,6 +868,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.13"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   wakelock:
     dependency: transitive
     description:
@@ -949,5 +981,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=2.19.0-345.0.dev <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=3.3.0"

--- a/lib/src/domain/model/menu_entry.dart
+++ b/lib/src/domain/model/menu_entry.dart
@@ -5,6 +5,7 @@ class MenuEntry {
   const MenuEntry({
     required this.label,
     this.shortcut,
+    this.isActivated,
     this.onPressed,
     this.menuChildren,
   }) : assert(menuChildren == null || onPressed == null,
@@ -12,6 +13,7 @@ class MenuEntry {
   final String label;
 
   final MenuSerializableShortcut? shortcut;
+  final bool Function()? isActivated;
   final VoidCallback? onPressed;
   final List<MenuEntry>? menuChildren;
 
@@ -55,6 +57,10 @@ class MenuEntry {
       } else {
         return MenuItemButton(
           shortcut: selection.shortcut,
+          trailingIcon:
+              selection.isActivated != null && selection.isActivated!()
+                  ? const Icon(Icons.check)
+                  : SizedBox.fromSize(size: const Size(22, 0)),
           onPressed: selection.onPressed,
           child: Text(selection.label),
         );

--- a/lib/src/domain/model/node.dart
+++ b/lib/src/domain/model/node.dart
@@ -30,14 +30,28 @@ class InfiniteCanvasNode<T> {
   static const double dragHandleSize = 10;
   static const double borderInset = 2;
 
-  void update({Size? size, Offset? offset, String? label, bool? setCurrentlyResizing}) {
+  void update(
+      {Size? size,
+      Offset? offset,
+      String? label,
+      bool? setCurrentlyResizing,
+      bool? snapMovementToGrid,
+      Size? gridSize}) {
     if (setCurrentlyResizing != null) {
       currentlyResizing = setCurrentlyResizing;
     }
-    if (offset != null &&
-        (setCurrentlyResizing == true || (setCurrentlyResizing == null && allowMove && !currentlyResizing))) {
+
+    if (offset != null && setCurrentlyResizing == true) {
       this.offset = offset;
+    } else if (offset != null &&
+        setCurrentlyResizing == null &&
+        allowMove &&
+        !currentlyResizing) {
+      this.offset = snapMovementToGrid == true && gridSize != null
+          ? _adjustOffsetToGrid(offset, gridSize)
+          : offset;
     }
+
     if (size != null && resizeMode.isEnabled) {
       if (size.width < dragHandleSize * 2) {
         size = Size(dragHandleSize * 2, size.height);
@@ -49,6 +63,13 @@ class InfiniteCanvasNode<T> {
     }
     if (label != null) this.label = label;
   }
+
+  Offset _adjustOffsetToGrid(Offset rawOffset, Size gridSize) {
+    return Offset(
+      (rawOffset.dx / gridSize.width).roundToDouble() * gridSize.width,
+      (rawOffset.dy / gridSize.height).roundToDouble() * gridSize.height,
+    );
+  }
 }
 
 enum ResizeMode {
@@ -58,6 +79,8 @@ enum ResizeMode {
   cornersAndEdges;
 
   bool get isEnabled => this != ResizeMode.disabled;
-  bool get containsCornerHandles => this == ResizeMode.corners || this == ResizeMode.cornersAndEdges;
-  bool get containsEdgeHandles => this == ResizeMode.edges || this == ResizeMode.cornersAndEdges;
+  bool get containsCornerHandles =>
+      this == ResizeMode.corners || this == ResizeMode.cornersAndEdges;
+  bool get containsEdgeHandles =>
+      this == ResizeMode.edges || this == ResizeMode.cornersAndEdges;
 }

--- a/lib/src/domain/model/node.dart
+++ b/lib/src/domain/model/node.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:infinite_canvas/src/presentation/utils/helpers.dart';
 
 /// A node in the [InfiniteCanvas].
 class InfiniteCanvasNode<T> {
@@ -47,9 +48,15 @@ class InfiniteCanvasNode<T> {
         setCurrentlyResizing == null &&
         allowMove &&
         !currentlyResizing) {
-      this.offset = snapMovementToGrid == true && gridSize != null
-          ? _adjustOffsetToGrid(offset, gridSize)
-          : offset;
+      if (snapMovementToGrid == true && gridSize != null) {
+        final snappedX = _getClosestSnapPosition(
+            offset.dx, size?.width ?? this.size.width, gridSize.width);
+        final snappedY = _getClosestSnapPosition(
+            offset.dy, size?.height ?? this.size.height, gridSize.height);
+        this.offset = Offset(snappedX, snappedY);
+      } else {
+        this.offset = offset;
+      }
     }
 
     if (size != null && resizeMode.isEnabled) {
@@ -64,11 +71,18 @@ class InfiniteCanvasNode<T> {
     if (label != null) this.label = label;
   }
 
-  Offset _adjustOffsetToGrid(Offset rawOffset, Size gridSize) {
-    return Offset(
-      (rawOffset.dx / gridSize.width).roundToDouble() * gridSize.width,
-      (rawOffset.dy / gridSize.height).roundToDouble() * gridSize.height,
-    );
+  double _getClosestSnapPosition(
+      double rawEdge, double nodeLength, double gridEdge) {
+    final snapAtStartPos = adjustEdgeToGrid(rawEdge, gridEdge);
+    final snapAtStartDelta = (snapAtStartPos - rawEdge).abs();
+    final snapAtEndPos =
+        adjustEdgeToGrid(rawEdge + nodeLength, gridEdge) - nodeLength;
+    final snapAtEndDelta = (snapAtEndPos - rawEdge).abs();
+
+    if (snapAtEndDelta < snapAtStartDelta) {
+      return snapAtEndPos;
+    }
+    return snapAtStartPos;
   }
 }
 

--- a/lib/src/domain/model/node.dart
+++ b/lib/src/domain/model/node.dart
@@ -8,7 +8,7 @@ class InfiniteCanvasNode<T> {
     required this.offset,
     required this.child,
     this.label,
-    this.allowResize = false,
+    this.resizeMode = ResizeMode.disabled,
     this.allowMove = true,
     this.clipBehavior = Clip.none,
     this.value,
@@ -22,7 +22,8 @@ class InfiniteCanvasNode<T> {
   String? label;
   T? value;
   final Widget child;
-  final bool allowResize, allowMove;
+  final ResizeMode resizeMode;
+  final bool allowMove;
   final Clip clipBehavior;
   Rect get rect => offset & size;
   static const double dragHandleSize = 10;
@@ -34,7 +35,7 @@ class InfiniteCanvasNode<T> {
     String? label,
   }) {
     if (offset != null && allowMove) this.offset = offset;
-    if (size != null && allowResize) {
+    if (size != null && resizeMode.isEnabled) {
       if (size.width < dragHandleSize * 2) {
         size = Size(dragHandleSize * 2, size.height);
       }
@@ -45,4 +46,15 @@ class InfiniteCanvasNode<T> {
     }
     if (label != null) this.label = label;
   }
+}
+
+enum ResizeMode {
+  disabled,
+  corners,
+  edges,
+  cornersAndEdges;
+
+  bool get isEnabled => this != ResizeMode.disabled;
+  bool get containsCornerHandles => this == ResizeMode.corners || this == ResizeMode.cornersAndEdges;
+  bool get containsEdgeHandles => this == ResizeMode.edges || this == ResizeMode.cornersAndEdges;
 }

--- a/lib/src/domain/model/node.dart
+++ b/lib/src/domain/model/node.dart
@@ -23,18 +23,21 @@ class InfiniteCanvasNode<T> {
   T? value;
   final Widget child;
   final ResizeMode resizeMode;
+  bool currentlyResizing = false;
   final bool allowMove;
   final Clip clipBehavior;
   Rect get rect => offset & size;
   static const double dragHandleSize = 10;
   static const double borderInset = 2;
 
-  void update({
-    Size? size,
-    Offset? offset,
-    String? label,
-  }) {
-    if (offset != null && allowMove) this.offset = offset;
+  void update({Size? size, Offset? offset, String? label, bool? setCurrentlyResizing}) {
+    if (setCurrentlyResizing != null) {
+      currentlyResizing = setCurrentlyResizing;
+    }
+    if (offset != null &&
+        (setCurrentlyResizing == true || (setCurrentlyResizing == null && allowMove && !currentlyResizing))) {
+      this.offset = offset;
+    }
     if (size != null && resizeMode.isEnabled) {
       if (size.width < dragHandleSize * 2) {
         size = Size(dragHandleSize * 2, size.height);

--- a/lib/src/presentation/state/controller.dart
+++ b/lib/src/presentation/state/controller.dart
@@ -11,16 +11,19 @@ typedef NodeFormatter = void Function(InfiniteCanvasNode);
 
 /// A controller for the [InfiniteCanvas].
 class InfiniteCanvasController extends ChangeNotifier implements Graph {
-  InfiniteCanvasController({
-    List<InfiniteCanvasNode> nodes = const [],
-    List<InfiniteCanvasEdge> edges = const [],
-  }) {
+  InfiniteCanvasController(
+      {List<InfiniteCanvasNode> nodes = const [],
+      List<InfiniteCanvasEdge> edges = const [],
+      bool snapMovementToGrid = false,
+      bool snapResizeToGrid = false}) {
     if (nodes.isNotEmpty) {
       this.nodes.addAll(nodes);
     }
     if (edges.isNotEmpty) {
       this.edges.addAll(edges);
     }
+    _snapMovementToGrid = snapMovementToGrid;
+    _snapResizeToGrid = snapResizeToGrid;
   }
 
   double minScale = 0.4;
@@ -33,6 +36,14 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
 
   @override
   final List<InfiniteCanvasEdge> edges = [];
+
+  late bool _snapMovementToGrid;
+  bool get snapMovementToGrid => _snapMovementToGrid;
+  set snapMovementToGrid(newValue) => _snapMovementToGrid = newValue;
+
+  late bool _snapResizeToGrid;
+  bool get snapResizeToGrid => _snapResizeToGrid;
+  set snapResizeToGrid(newValue) => _snapResizeToGrid = newValue;
 
   final Set<Key> _selected = {};
   List<InfiniteCanvasNode> get selection => nodes.where((e) => _selected.contains(e.key)).toList();
@@ -228,14 +239,14 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
     notifyListeners();
   }
 
-  void moveSelection(Offset position) {
+  void moveSelection(Offset position, {Size? gridSize}) {
     final delta = mouseDragStart != null ? toLocal(position) - toLocal(mouseDragStart!) : toLocal(position);
     for (final key in _selected) {
       final index = nodes.indexWhere((e) => e.key == key);
       if (index == -1) continue;
       final current = nodes[index];
       final origin = _selectedOrigins[key];
-      current.update(offset: origin! + delta);
+      current.update(offset: origin! + delta, snapMovementToGrid: snapMovementToGrid, gridSize: gridSize);
       if (_formatter != null) {
         _formatter!(current);
       }

--- a/lib/src/presentation/state/controller.dart
+++ b/lib/src/presentation/state/controller.dart
@@ -46,9 +46,11 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   set snapResizeToGrid(newValue) => _snapResizeToGrid = newValue;
 
   final Set<Key> _selected = {};
-  List<InfiniteCanvasNode> get selection => nodes.where((e) => _selected.contains(e.key)).toList();
+  List<InfiniteCanvasNode> get selection =>
+      nodes.where((e) => _selected.contains(e.key)).toList();
   final Set<Key> _hovered = {};
-  List<InfiniteCanvasNode> get hovered => nodes.where((e) => _hovered.contains(e.key)).toList();
+  List<InfiniteCanvasNode> get hovered =>
+      nodes.where((e) => _hovered.contains(e.key)).toList();
 
   void _cacheSelectedOrigins() {
     // cache selected node origins
@@ -240,13 +242,18 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   }
 
   void moveSelection(Offset position, {Size? gridSize}) {
-    final delta = mouseDragStart != null ? toLocal(position) - toLocal(mouseDragStart!) : toLocal(position);
+    final delta = mouseDragStart != null
+        ? toLocal(position) - toLocal(mouseDragStart!)
+        : toLocal(position);
     for (final key in _selected) {
       final index = nodes.indexWhere((e) => e.key == key);
       if (index == -1) continue;
       final current = nodes[index];
       final origin = _selectedOrigins[key];
-      current.update(offset: origin! + delta, snapMovementToGrid: snapMovementToGrid, gridSize: gridSize);
+      current.update(
+          offset: origin! + delta,
+          snapMovementToGrid: snapMovementToGrid,
+          gridSize: gridSize);
       if (_formatter != null) {
         _formatter!(current);
       }
@@ -435,5 +442,12 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
     final scale = matrix.getMaxScaleOnAxis();
     final size = constraints.biggest;
     return offset & size / scale;
+  }
+
+  void toggleSnapToGrid() {
+    final newSnapValue = !snapMovementToGrid;
+    snapMovementToGrid = newSnapValue;
+    snapResizeToGrid = newSnapValue;
+    notifyListeners();
   }
 }

--- a/lib/src/presentation/state/controller.dart
+++ b/lib/src/presentation/state/controller.dart
@@ -35,11 +35,9 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   final List<InfiniteCanvasEdge> edges = [];
 
   final Set<Key> _selected = {};
-  List<InfiniteCanvasNode> get selection =>
-      nodes.where((e) => _selected.contains(e.key)).toList();
+  List<InfiniteCanvasNode> get selection => nodes.where((e) => _selected.contains(e.key)).toList();
   final Set<Key> _hovered = {};
-  List<InfiniteCanvasNode> get hovered =>
-      nodes.where((e) => _hovered.contains(e.key)).toList();
+  List<InfiniteCanvasNode> get hovered => nodes.where((e) => _hovered.contains(e.key)).toList();
 
   void _cacheSelectedOrigins() {
     // cache selected node origins
@@ -231,9 +229,7 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
   }
 
   void moveSelection(Offset position) {
-    final delta = mouseDragStart != null
-        ? toLocal(position) - toLocal(mouseDragStart!)
-        : toLocal(position);
+    final delta = mouseDragStart != null ? toLocal(position) - toLocal(mouseDragStart!) : toLocal(position);
     for (final key in _selected) {
       final index = nodes.indexWhere((e) => e.key == key);
       if (index == -1) continue;
@@ -302,6 +298,9 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
     if (_selected.length == 1) {
       final idx = nodes.indexWhere((e) => e.key == _selected.first);
       nodes[idx] = child;
+      if (_formatter != null) {
+        _formatter!(child);
+      }
       notifyListeners();
     }
   }

--- a/lib/src/presentation/utils/helpers.dart
+++ b/lib/src/presentation/utils/helpers.dart
@@ -1,0 +1,11 @@
+double adjustEdgeToGrid(double rawOffsetEdge, double gridEdge,
+    {double? minimum, double? maximum}) {
+  double snappedBound = (rawOffsetEdge / gridEdge).roundToDouble() * gridEdge;
+  if (minimum != null && snappedBound < minimum) {
+    return minimum;
+  }
+  if (maximum != null && snappedBound > maximum) {
+    return maximum;
+  }
+  return snappedBound;
+}

--- a/lib/src/presentation/view/canvas.dart
+++ b/lib/src/presentation/view/canvas.dart
@@ -270,7 +270,8 @@ class InfiniteCanvasState extends State<InfiniteCanvas> {
                     controller.pan(details.focalPointDelta);
                   } else if (controller.controlPressed) {
                   } else {
-                    controller.moveSelection(details.focalPoint);
+                    controller.moveSelection(details.focalPoint,
+                        gridSize: widget.gridSize);
                   }
                   controller.mousePosition = details.focalPoint;
                 },

--- a/lib/src/presentation/widgets/drag_handle.dart
+++ b/lib/src/presentation/widgets/drag_handle.dart
@@ -1,26 +1,142 @@
 import 'package:flutter/material.dart';
+import 'package:infinite_canvas/infinite_canvas.dart';
 
-class DragHandle extends StatelessWidget {
+class DragHandle extends StatefulWidget {
+  final InfiniteCanvasController controller;
+  final InfiniteCanvasNode node;
+  final DragHandleAlignment alignment;
+  final double size;
+  final Size gridSize;
+  final bool snapToGrid;
+
   const DragHandle({
     super.key,
+    required this.controller,
+    required this.node,
+    required this.alignment,
     this.size = 10,
+    required this.gridSize,
+    this.snapToGrid = false,
   });
 
-  final double size;
+  @override
+  State<DragHandle> createState() => _DragHandleState();
+}
+
+class _DragHandleState extends State<DragHandle> {
+  late final InfiniteCanvasController controller;
+  late final InfiniteCanvasNode node;
+  late final DragHandleAlignment al;
+  late final double size;
+  late final Size gridSize;
+  late final bool snapToGrid;
+
+  late Offset initialNodeOffset;
+  late Size initialNodeSize;
+  late Offset draggingOffset;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = widget.controller;
+    node = widget.node;
+    al = widget.alignment;
+    size = widget.size;
+    gridSize = widget.gridSize;
+    snapToGrid = widget.snapToGrid;
+  }
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
-    return Container(
-      height: size,
-      width: size,
-      decoration: BoxDecoration(
-        color: colors.surfaceVariant,
-        border: Border.all(
-          color: colors.onSurfaceVariant,
-          width: 1,
-        ),
-      ),
-    );
+    return Listener(
+        onPointerDown: (details) {
+          initialNodeOffset = node.offset;
+          initialNodeSize = node.size;
+          draggingOffset = Offset.zero;
+        },
+        onPointerUp: (details) {
+          node.update(setCurrentlyResizing: false);
+        },
+        onPointerCancel: (details) {
+          node.update(setCurrentlyResizing: false);
+        },
+        onPointerMove: (details) {
+          if (!widget.controller.mouseDown) return;
+
+          draggingOffset = draggingOffset + details.delta;
+          Offset newTopLeftCorner = initialNodeOffset;
+          Size newSize = initialNodeSize;
+
+          if (al.isLeft) {
+            newTopLeftCorner = newTopLeftCorner.translate(draggingOffset.dx, 0);
+            newSize = Size(initialNodeOffset.dx + newSize.width - newTopLeftCorner.dx, newSize.height);
+          }
+          if (al.isTop) {
+            newTopLeftCorner = newTopLeftCorner.translate(0, draggingOffset.dy);
+            newSize = Size(newSize.width, initialNodeOffset.dy + newSize.height - newTopLeftCorner.dy);
+          }
+          if (al.isRight) {
+            newSize = Size(newSize.width + draggingOffset.dx, newSize.height);
+          }
+          if (al.isBottom) {
+            newSize = Size(newSize.width, newSize.height + draggingOffset.dy);
+          }
+
+          // if (!snapToGrid) {
+          //   // node.update(size: newSize, offset: newTopLeftCorner);
+          // } else {
+          //   // print(draggingOffset);
+          //   final newTopLeftCorner = Offset(
+          //       al.isLeft ? _adjustOffsetXToGrid(initialNodeOffset.dx + draggingOffset.dx) : initialNodeOffset.dx,
+          //       al.isTop ? _adjustOffsetYToGrid(initialNodeOffset.dy + draggingOffset.dy) : initialNodeOffset.dy);
+          //   final newBottomRightCorner = Offset(
+          //       al.isRight
+          //           ? _adjustOffsetXToGrid(newTopLeftCorner.dx + initialNodeSize.width + draggingOffset.dx)
+          //           : node.offset.dx + node.size.width,
+          //       al.isBottom
+          //           ? _adjustOffsetYToGrid(newTopLeftCorner.dy + initialNodeSize.height + draggingOffset.dy)
+          //           : node.offset.dy + node.size.height);
+          //   final newSize =
+          //       Size(newBottomRightCorner.dx - newTopLeftCorner.dx, newBottomRightCorner.dy - newTopLeftCorner.dy);
+
+          // print(newBottomRightCorner);
+          // print(newSize);
+          node.update(size: newSize, offset: newTopLeftCorner, setCurrentlyResizing: true);
+
+          controller.edit(node);
+        },
+        child: Container(
+          height: size,
+          width: size,
+          decoration: BoxDecoration(
+            color: colors.surfaceVariant,
+            border: Border.all(
+              color: colors.onSurfaceVariant,
+              width: 1,
+            ),
+          ),
+        ));
   }
+
+  double _adjustOffsetXToGrid(double rawOffset) {
+    return (rawOffset / gridSize.width).roundToDouble() * gridSize.width;
+  }
+
+  double _adjustOffsetYToGrid(double rawOffset) {
+    return (rawOffset / gridSize.height).roundToDouble() * gridSize.height;
+  }
+}
+
+class DragHandleAlignment {
+  final Alignment alignment;
+
+  const DragHandleAlignment(this.alignment);
+
+  bool get isLeft => alignment.x < 0;
+  bool get isRight => alignment.x > 0;
+  bool get isTop => alignment.y < 0;
+  bool get isBottom => alignment.y > 0;
+  bool get isHorizontalCenter => alignment.x == 0;
+  bool get isVerticalCenter => alignment.y == 0;
 }

--- a/lib/src/presentation/widgets/drag_handle.dart
+++ b/lib/src/presentation/widgets/drag_handle.dart
@@ -9,7 +9,7 @@ class DragHandle extends StatefulWidget {
   final DragHandleAlignment alignment;
   final double size;
   final Size gridSize;
-  final bool snapToGrid;
+  final bool initialSnapToGrid;
   final Size minimumNodeSize;
 
   const DragHandle({
@@ -19,8 +19,9 @@ class DragHandle extends StatefulWidget {
     required this.alignment,
     this.size = 10,
     required this.gridSize,
-    this.snapToGrid = true,
-    this.minimumNodeSize = const Size(InfiniteCanvasNode.dragHandleSize * 2, InfiniteCanvasNode.dragHandleSize * 2),
+    this.initialSnapToGrid = true,
+    this.minimumNodeSize = const Size(InfiniteCanvasNode.dragHandleSize * 2,
+        InfiniteCanvasNode.dragHandleSize * 2),
   });
 
   @override
@@ -33,7 +34,7 @@ class _DragHandleState extends State<DragHandle> {
   late final DragHandleAlignment al;
   late final double size;
   late final Size gridSize;
-  late final bool snapToGrid;
+  late bool snapToGrid;
   late final Size minimumNodeSize;
 
   late Rect initialBounds;
@@ -48,8 +49,12 @@ class _DragHandleState extends State<DragHandle> {
     al = widget.alignment;
     size = widget.size;
     gridSize = widget.gridSize;
-    snapToGrid = widget.snapToGrid;
+    snapToGrid = widget.initialSnapToGrid;
     minimumNodeSize = widget.minimumNodeSize;
+
+    controller.addListener(() {
+      snapToGrid = controller.snapResizeToGrid;
+    });
   }
 
   @override
@@ -57,7 +62,8 @@ class _DragHandleState extends State<DragHandle> {
     final colors = Theme.of(context).colorScheme;
     return Listener(
         onPointerDown: (details) {
-          initialBounds = Rect.fromLTWH(node.offset.dx, node.offset.dy, node.size.width, node.size.height);
+          initialBounds = Rect.fromLTWH(node.offset.dx, node.offset.dy,
+              node.size.width, node.size.height);
           minimumSizeBounds = Rect.fromLTRB(
               initialBounds.right - minimumNodeSize.width,
               initialBounds.bottom - minimumNodeSize.height,
@@ -78,37 +84,61 @@ class _DragHandleState extends State<DragHandle> {
           Rect newBounds = initialBounds;
 
           if (al.isLeft) {
-            newBounds = Rect.fromLTRB(min(minimumSizeBounds.left, newBounds.left + draggingOffset.dx), newBounds.top,
-                newBounds.right, newBounds.bottom);
+            newBounds = Rect.fromLTRB(
+                min(minimumSizeBounds.left, newBounds.left + draggingOffset.dx),
+                newBounds.top,
+                newBounds.right,
+                newBounds.bottom);
           }
           if (al.isTop) {
-            newBounds = Rect.fromLTRB(newBounds.left, min(minimumSizeBounds.top, newBounds.top + draggingOffset.dy),
-                newBounds.right, newBounds.bottom);
+            newBounds = Rect.fromLTRB(
+                newBounds.left,
+                min(minimumSizeBounds.top, newBounds.top + draggingOffset.dy),
+                newBounds.right,
+                newBounds.bottom);
           }
 
           if (snapToGrid && (al.isLeft || al.isTop)) {
-            final snappedLeft = _adjustEdgeToGrid(newBounds.left, gridSize.width, maximum: minimumSizeBounds.left);
-            final snappedTop = _adjustEdgeToGrid(newBounds.top, gridSize.height, maximum: minimumSizeBounds.top);
-            newBounds = Rect.fromLTRB(snappedLeft, snappedTop, newBounds.right, newBounds.bottom);
+            final snappedLeft = _adjustEdgeToGrid(
+                newBounds.left, gridSize.width,
+                maximum: minimumSizeBounds.left);
+            final snappedTop = _adjustEdgeToGrid(newBounds.top, gridSize.height,
+                maximum: minimumSizeBounds.top);
+            newBounds = Rect.fromLTRB(
+                snappedLeft, snappedTop, newBounds.right, newBounds.bottom);
           }
 
           if (al.isRight) {
-            newBounds = Rect.fromLTWH(newBounds.left, newBounds.top,
-                max(minimumNodeSize.width, newBounds.width + draggingOffset.dx), newBounds.height);
+            newBounds = Rect.fromLTWH(
+                newBounds.left,
+                newBounds.top,
+                max(minimumNodeSize.width, newBounds.width + draggingOffset.dx),
+                newBounds.height);
           }
           if (al.isBottom) {
-            newBounds = Rect.fromLTWH(newBounds.left, newBounds.top, newBounds.width,
-                max(minimumNodeSize.height, newBounds.height + draggingOffset.dy));
+            newBounds = Rect.fromLTWH(
+                newBounds.left,
+                newBounds.top,
+                newBounds.width,
+                max(minimumNodeSize.height,
+                    newBounds.height + draggingOffset.dy));
           }
 
           if (snapToGrid && (al.isRight || al.isBottom)) {
-            final snappedRight = _adjustEdgeToGrid(newBounds.right, gridSize.width, minimum: minimumSizeBounds.right);
-            final snappedBottom =
-                _adjustEdgeToGrid(newBounds.bottom, gridSize.height, minimum: minimumSizeBounds.bottom);
-            newBounds = Rect.fromLTRB(newBounds.left, newBounds.top, snappedRight, snappedBottom);
+            final snappedRight = _adjustEdgeToGrid(
+                newBounds.right, gridSize.width,
+                minimum: minimumSizeBounds.right);
+            final snappedBottom = _adjustEdgeToGrid(
+                newBounds.bottom, gridSize.height,
+                minimum: minimumSizeBounds.bottom);
+            newBounds = Rect.fromLTRB(
+                newBounds.left, newBounds.top, snappedRight, snappedBottom);
           }
 
-          node.update(size: newBounds.size, offset: newBounds.topLeft, setCurrentlyResizing: true);
+          node.update(
+              size: newBounds.size,
+              offset: newBounds.topLeft,
+              setCurrentlyResizing: true);
           controller.edit(node);
         },
         child: Container(
@@ -124,7 +154,8 @@ class _DragHandleState extends State<DragHandle> {
         ));
   }
 
-  double _adjustEdgeToGrid(double rawOffsetEdge, double gridEdge, {double? minimum, double? maximum}) {
+  double _adjustEdgeToGrid(double rawOffsetEdge, double gridEdge,
+      {double? minimum, double? maximum}) {
     double snappedBound = (rawOffsetEdge / gridEdge).roundToDouble() * gridEdge;
     if (minimum != null && snappedBound < minimum) {
       return minimum;

--- a/lib/src/presentation/widgets/drag_handle.dart
+++ b/lib/src/presentation/widgets/drag_handle.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class DragHandel extends StatelessWidget {
-  const DragHandel({
+class DragHandle extends StatelessWidget {
+  const DragHandle({
     super.key,
     this.size = 10,
   });

--- a/lib/src/presentation/widgets/drag_handle.dart
+++ b/lib/src/presentation/widgets/drag_handle.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:infinite_canvas/infinite_canvas.dart';
+import 'package:infinite_canvas/src/presentation/utils/helpers.dart';
 
 class DragHandle extends StatefulWidget {
   final InfiniteCanvasController controller;
@@ -99,10 +100,9 @@ class _DragHandleState extends State<DragHandle> {
           }
 
           if (snapToGrid && (al.isLeft || al.isTop)) {
-            final snappedLeft = _adjustEdgeToGrid(
-                newBounds.left, gridSize.width,
+            final snappedLeft = adjustEdgeToGrid(newBounds.left, gridSize.width,
                 maximum: minimumSizeBounds.left);
-            final snappedTop = _adjustEdgeToGrid(newBounds.top, gridSize.height,
+            final snappedTop = adjustEdgeToGrid(newBounds.top, gridSize.height,
                 maximum: minimumSizeBounds.top);
             newBounds = Rect.fromLTRB(
                 snappedLeft, snappedTop, newBounds.right, newBounds.bottom);
@@ -125,10 +125,10 @@ class _DragHandleState extends State<DragHandle> {
           }
 
           if (snapToGrid && (al.isRight || al.isBottom)) {
-            final snappedRight = _adjustEdgeToGrid(
+            final snappedRight = adjustEdgeToGrid(
                 newBounds.right, gridSize.width,
                 minimum: minimumSizeBounds.right);
-            final snappedBottom = _adjustEdgeToGrid(
+            final snappedBottom = adjustEdgeToGrid(
                 newBounds.bottom, gridSize.height,
                 minimum: minimumSizeBounds.bottom);
             newBounds = Rect.fromLTRB(
@@ -152,18 +152,6 @@ class _DragHandleState extends State<DragHandle> {
             ),
           ),
         ));
-  }
-
-  double _adjustEdgeToGrid(double rawOffsetEdge, double gridEdge,
-      {double? minimum, double? maximum}) {
-    double snappedBound = (rawOffsetEdge / gridEdge).roundToDouble() * gridEdge;
-    if (minimum != null && snappedBound < minimum) {
-      return minimum;
-    }
-    if (maximum != null && snappedBound > maximum) {
-      return maximum;
-    }
-    return snappedBound;
   }
 }
 

--- a/lib/src/presentation/widgets/menus.dart
+++ b/lib/src/presentation/widgets/menus.dart
@@ -15,7 +15,7 @@ class Menus extends StatefulWidget {
     this.renameLabel,
     this.visible = true,
   });
-  
+
   final List<MenuEntry> menus;
   final InfiniteCanvasController controller;
   final String Function(String)? renameLabel;
@@ -213,6 +213,20 @@ class _MenusState extends State<Menus> {
     );
   }
 
+  MenuEntry buildSettings(BuildContext context) {
+    return MenuEntry(
+      label: 'Settings',
+      menuChildren: [
+        MenuEntry(
+          label: 'Snap To Grid',
+          isActivated: () => widget.controller.snapMovementToGrid,
+          onPressed: widget.controller.toggleSnapToGrid,
+          shortcut: const SingleActivator(LogicalKeyboardKey.keyG, meta: true),
+        )
+      ],
+    );
+  }
+
   List<MenuEntry> merge(BuildContext context) {
     final menus = <MenuEntry>[];
     menus.addAll(widget.menus);
@@ -233,6 +247,16 @@ class _MenusState extends State<Menus> {
       final value = menus[idx];
       final children = value.menuChildren ?? [];
       final merged = buildEdit(context).merge(children);
+      menus.removeAt(idx);
+      menus.insert(idx, merged);
+    }
+    if (!menus.map((e) => e.label).contains('Settings')) {
+      menus.add(buildSettings(context));
+    } else {
+      final idx = menus.indexWhere((e) => e.label == 'Settings');
+      final value = menus[idx];
+      final children = value.menuChildren ?? [];
+      final merged = buildSettings(context).merge(children);
       menus.removeAt(idx);
       menus.insert(idx, merged);
     }

--- a/lib/src/presentation/widgets/node_renderer.dart
+++ b/lib/src/presentation/widgets/node_renderer.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../../domain/model/node.dart';
 import '../state/controller.dart';
 import 'clipper.dart';
-import 'drag_handel.dart';
+import 'drag_handle.dart';
 
 class NodeRenderer extends StatelessWidget {
   const NodeRenderer({
@@ -21,125 +21,101 @@ class NodeRenderer extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     final fonts = Theme.of(context).textTheme;
-    final showHandles = node.allowResize && controller.isSelected(node.key);
+    final showCornerHandles = node.resizeMode.containsCornerHandles && controller.isSelected(node.key);
+    final showEdgeHandles = node.resizeMode.containsEdgeHandles && controller.isSelected(node.key);
     return SizedBox.fromSize(
       size: node.size,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          if (node.label != null)
-            Positioned(
-              top: -25,
-              left: 0,
-              child: Text(
-                node.label!,
-                style: fonts.bodyMedium?.copyWith(
-                  color: colors.onSurface,
-                  shadows: [
-                    Shadow(
-                      offset: const Offset(0.8, 0.8),
-                      blurRadius: 3,
-                      color: colors.surface,
-                    ),
-                  ],
-                ),
+      child: Stack(clipBehavior: Clip.none, children: [
+        if (node.label != null)
+          Positioned(
+            top: -25,
+            left: 0,
+            child: Text(
+              node.label!,
+              style: fonts.bodyMedium?.copyWith(
+                color: colors.onSurface,
+                shadows: [
+                  Shadow(
+                    offset: const Offset(0.8, 0.8),
+                    blurRadius: 3,
+                    color: colors.surface,
+                  ),
+                ],
               ),
             ),
-          if (controller.isSelected(node.key) || controller.isHovered(node.key))
-            Positioned(
-              top: -borderInset,
-              left: -borderInset,
-              right: -borderInset,
-              bottom: -borderInset,
-              child: IgnorePointer(
-                child: Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                      color: controller.isSelected(node.key)
-                          ? colors.primary
-                          : colors.outline,
-                      width: 1,
-                    ),
+          ),
+        if (controller.isSelected(node.key) || controller.isHovered(node.key))
+          Positioned(
+            top: -borderInset,
+            left: -borderInset,
+            right: -borderInset,
+            bottom: -borderInset,
+            child: IgnorePointer(
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: controller.isSelected(node.key) ? colors.primary : colors.outline,
+                    width: 1,
                   ),
                 ),
               ),
             ),
-          Positioned.fill(
-            key: key,
-            child: node.clipBehavior != Clip.none
-                ? ClipRect(
-                    clipper: Clipper(node.rect),
-                    clipBehavior: node.clipBehavior,
-                    child: node.child,
-                  )
-                : node.child,
           ),
-          if (showHandles) ...[
-            // bottom right
-            Positioned(
-              right: 0,
-              bottom: 0,
-              child: GestureDetector(
-                onPanUpdate: (details) {
-                  if (!controller.mouseDown) return;
-                  node.update(size: node.size + details.delta);
-                  controller.edit(node);
-                },
-                child: const DragHandel(),
-              ),
-            ),
-            // bottom left
-            Positioned(
-              left: 0,
-              bottom: 0,
-              child: GestureDetector(
-                onPanUpdate: (details) {
-                  if (!controller.mouseDown) return;
-                  node.update(
-                    size:
-                        node.size + Offset(-details.delta.dx, details.delta.dy),
-                    offset: node.offset + Offset(details.delta.dx, 0),
-                  );
-                  controller.edit(node);
-                },
-                child: const DragHandel(),
-              ),
-            ),
-            // top right
-            Positioned(
-              right: 0,
-              top: 0,
-              child: GestureDetector(
-                onPanUpdate: (details) {
-                  if (!controller.mouseDown) return;
-                  node.update(
-                    size:
-                        node.size + Offset(details.delta.dx, -details.delta.dy),
-                    offset: node.offset + Offset(0, details.delta.dy),
-                  );
-                  controller.edit(node);
-                },
-                child: const DragHandel(),
-              ),
-            ),
-            // top left
-            Positioned(
-              left: 0,
-              top: 0,
-              child: GestureDetector(
-                onPanUpdate: (details) {
-                  if (!controller.mouseDown) return;
-                  node.update(
-                    size: node.size + -details.delta,
-                    offset: node.offset + details.delta,
-                  );
-                  controller.edit(node);
-                },
-                child: const DragHandel(),
-              ),
-            ),
-          ],
+        Positioned.fill(
+          key: key,
+          child: node.clipBehavior != Clip.none
+              ? ClipRect(
+                  clipper: Clipper(node.rect),
+                  clipBehavior: node.clipBehavior,
+                  child: node.child,
+                )
+              : node.child,
+        ),
+        if (showCornerHandles) ...[
+          _buildDragHandle(Alignment.bottomRight),
+          _buildDragHandle(Alignment.bottomLeft),
+          _buildDragHandle(Alignment.topRight),
+          _buildDragHandle(Alignment.topLeft),
         ],
+        if (showEdgeHandles) ...[
+          _buildDragHandle(Alignment.centerLeft),
+          _buildDragHandle(Alignment.centerRight),
+          _buildDragHandle(Alignment.topCenter),
+          _buildDragHandle(Alignment.bottomCenter),
+        ],
+      ]),
+    );
+  }
+
+  Positioned _buildDragHandle(Alignment alignment) {
+    final isLeft = alignment.x < 0;
+    final isRight = alignment.x > 0;
+    final isTop = alignment.y < 0;
+    final isBottom = alignment.y > 0;
+    final isHorizontalCenter = alignment.x == 0;
+    final isVerticalCenter = alignment.y == 0;
+    return Positioned(
+      left: isLeft
+          ? 0
+          : isHorizontalCenter
+              ? node.size.width / 2
+              : null,
+      right: isRight ? 0 : null,
+      top: isTop
+          ? 0
+          : isVerticalCenter
+              ? node.size.height / 2
+              : null,
+      bottom: isBottom ? 0 : null,
+      child: GestureDetector(
+        onPanUpdate: (details) {
+          if (!controller.mouseDown) return;
+          node.update(
+              size: node.size + details.delta.scale(alignment.x.sign, alignment.y.sign),
+              offset: node.offset + Offset(isLeft ? details.delta.dx : 0, isTop ? details.delta.dy : 0));
+          controller.edit(node);
+        },
+        child: const DragHandle(),
       ),
     );
   }

--- a/lib/src/presentation/widgets/node_renderer.dart
+++ b/lib/src/presentation/widgets/node_renderer.dart
@@ -87,36 +87,28 @@ class NodeRenderer extends StatelessWidget {
     );
   }
 
+  static const gridSize = Size.square(50);
+
   Positioned _buildDragHandle(Alignment alignment) {
-    final isLeft = alignment.x < 0;
-    final isRight = alignment.x > 0;
-    final isTop = alignment.y < 0;
-    final isBottom = alignment.y > 0;
-    final isHorizontalCenter = alignment.x == 0;
-    final isVerticalCenter = alignment.y == 0;
+    final dragHandleAlignment = DragHandleAlignment(alignment);
     return Positioned(
-      left: isLeft
-          ? 0
-          : isHorizontalCenter
-              ? node.size.width / 2
-              : null,
-      right: isRight ? 0 : null,
-      top: isTop
-          ? 0
-          : isVerticalCenter
-              ? node.size.height / 2
-              : null,
-      bottom: isBottom ? 0 : null,
-      child: GestureDetector(
-        onPanUpdate: (details) {
-          if (!controller.mouseDown) return;
-          node.update(
-              size: node.size + details.delta.scale(alignment.x.sign, alignment.y.sign),
-              offset: node.offset + Offset(isLeft ? details.delta.dx : 0, isTop ? details.delta.dy : 0));
-          controller.edit(node);
-        },
-        child: const DragHandle(),
-      ),
-    );
+        left: dragHandleAlignment.isLeft
+            ? 0
+            : dragHandleAlignment.isHorizontalCenter
+                ? node.size.width / 2
+                : null,
+        right: dragHandleAlignment.isRight ? 0 : null,
+        top: dragHandleAlignment.isTop
+            ? 0
+            : dragHandleAlignment.isVerticalCenter
+                ? node.size.height / 2
+                : null,
+        bottom: dragHandleAlignment.isBottom ? 0 : null,
+        child: DragHandle(
+          controller: controller,
+          node: node,
+          alignment: dragHandleAlignment,
+          gridSize: gridSize,
+        ));
   }
 }

--- a/lib/src/presentation/widgets/node_renderer.dart
+++ b/lib/src/presentation/widgets/node_renderer.dart
@@ -21,8 +21,10 @@ class NodeRenderer extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     final fonts = Theme.of(context).textTheme;
-    final showCornerHandles = node.resizeMode.containsCornerHandles && controller.isSelected(node.key);
-    final showEdgeHandles = node.resizeMode.containsEdgeHandles && controller.isSelected(node.key);
+    final showCornerHandles = node.resizeMode.containsCornerHandles &&
+        controller.isSelected(node.key);
+    final showEdgeHandles =
+        node.resizeMode.containsEdgeHandles && controller.isSelected(node.key);
     return SizedBox.fromSize(
       size: node.size,
       child: Stack(clipBehavior: Clip.none, children: [
@@ -54,7 +56,9 @@ class NodeRenderer extends StatelessWidget {
               child: Container(
                 decoration: BoxDecoration(
                   border: Border.all(
-                    color: controller.isSelected(node.key) ? colors.primary : colors.outline,
+                    color: controller.isSelected(node.key)
+                        ? colors.primary
+                        : colors.outline,
                     width: 1,
                   ),
                 ),
@@ -109,7 +113,7 @@ class NodeRenderer extends StatelessWidget {
           node: node,
           alignment: dragHandleAlignment,
           gridSize: gridSize,
-          snapToGrid: controller.snapResizeToGrid,
+          initialSnapToGrid: controller.snapResizeToGrid,
         ));
   }
 }

--- a/lib/src/presentation/widgets/node_renderer.dart
+++ b/lib/src/presentation/widgets/node_renderer.dart
@@ -109,6 +109,7 @@ class NodeRenderer extends StatelessWidget {
           node: node,
           alignment: dragHandleAlignment,
           gridSize: gridSize,
+          snapToGrid: controller.snapResizeToGrid,
         ));
   }
 }


### PR DESCRIPTION
- Added DragHandlers for edges to resize a node in only one dimension
- Added "resizeMode" attribute to Nodes to configure the amount of drag handlers
- Made movement and resizing of nodes smoother by replacing GestureDetector by Listener widget
- Implemented snapping to grid on resize
- Implemented snapping to grid on movement within the Node class without the need for a formatter, also snapping at the right or bottom edges (depending on proximity)
- Added "snapMovementToGrid" and "snapResizeToGrid" attributes to Controller to make snapping configurable individually for both actions
- Added "Settings" menu item with "Snap To Grid" option