### PR TITLE
Remap selection and panning

### DIFF
--- a/lib/src/presentation/state/controller.dart
+++ b/lib/src/presentation/state/controller.dart
@@ -121,14 +121,6 @@ class InfiniteCanvasController extends ChangeNotifier implements Graph {
     notifyListeners();
   }
 
-  bool _spacePressed = false;
-  bool get spacePressed => _spacePressed;
-  set spacePressed(bool value) {
-    if (value == _spacePressed) return;
-    _spacePressed = value;
-    notifyListeners();
-  }
-
   bool _controlPressed = false;
   bool get controlPressed => _controlPressed;
   set controlPressed(bool value) {

--- a/lib/src/presentation/view/canvas.dart
+++ b/lib/src/presentation/view/canvas.dart
@@ -200,10 +200,8 @@ class InfiniteCanvasState extends State<InfiniteCanvas> {
               if (controller.shiftPressed) {
                 controller.mouseDown = true;
               }
-              // if (!controller.spacePressed) {
-                controller.marqueeStart = details.localPosition;
-                controller.marqueeEnd = details.localPosition;
-              // }
+              controller.marqueeStart = details.localPosition;
+              controller.marqueeEnd = details.localPosition;
             }  else {
               controller.mouseDown = true;
               if (controller.controlPressed && widget.canAddEdges) {


### PR DESCRIPTION
Fixes #8

- When tapping/clicking and dragging a pan is invoked by the `InteractiveViewer` and the `Listener` is disabled.
- When pressing shift, objects can be selected by dragging.
- Removed `spacePressed` since it isn't needed anymore.

Small issue remaining: panning/zooming with touch only works in areas where no nodes are.
